### PR TITLE
Added quantum metrics for reliability of QPUs

### DIFF
--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/ErrorCorrectionEnabled.yml
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/ErrorCorrectionEnabled.yml
@@ -1,0 +1,9 @@
+--- # Metadata
+- id: ErrorCorrectionEnabled
+- description: This rule assesses whether a [QPU] has [ErrorCorrectionEnabled] [p1:enabled] correctly configured.
+- version: 1.0 
+- comments: Quantum error correction enables reliable execution of quantum circuits.
+--- # Configuration data
+- p1:
+  - operator: ==
+  - targetValue: True

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/ErrorCorrectionEnabled.yml
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/ErrorCorrectionEnabled.yml
@@ -1,9 +1,11 @@
---- # Metadata
-- id: ErrorCorrectionEnabled
-- description: This rule assesses whether a [QPU] has [ErrorCorrectionEnabled] [p1:enabled] correctly configured.
-- version: 1.0 
-- comments: Quantum error correction enables reliable execution of quantum circuits.
---- # Configuration data
-- p1:
-  - operator: ==
-  - targetValue: True
+# Metadata
+id: ErrorCorrectionEnabled
+description: This rule assesses whether a [QPU] has [ErrorCorrectionEnabled] [p1:enabled] correctly configured.
+version: 1.0 
+comments: Quantum error correction enables reliable execution of quantum circuits.
+--- 
+# Configuration data
+configuration:
+  p1:
+    operator: ==
+    targetValue: True

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/data.json
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/data.json
@@ -1,4 +1,4 @@
 {
-    "operator" : "<",
-    "target_value" : 0.0001
+    "operator" : "==",
+    "target_value" : true
 }

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/data.json
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/data.json
@@ -1,0 +1,4 @@
+{
+    "operator" : "<",
+    "target_value" : 0.0001
+}

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
@@ -1,0 +1,15 @@
+package metrics.quantum.reliability
+
+import data.compare
+
+default applicable = false
+
+default compliant = false
+
+applicable if {
+	input.ErrorCorrectionEnabled
+}
+
+compliant if {
+	compare(data.operator, data.target_value, input.ErrorCorrectionEnabled)
+}

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
@@ -8,7 +8,7 @@ default applicable = false
 default compliant = false
 
 applicable if {
-	input.ErrorCorrectionEnabled
+	input.type[_] == "QPU"
 }
 
 compliant if {

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
@@ -1,6 +1,6 @@
-package metrics.quantum.reliability
+package cch.metrics.quantum_error_correction_enabled
 
-import data.compare
+import data.cch.compare
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/ErrorCorrectionEnabled/metric.rego
@@ -1,6 +1,7 @@
 package cch.metrics.quantum_error_correction_enabled
 
 import data.cch.compare
+import rego.v1
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/OneQubitGateErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/OneQubitGateErrorRate.yml
@@ -1,0 +1,9 @@
+--- # Metadata
+- id: OneQubitGateErrorRate
+- description: This rule assesses whether a [QPU] has [OneQubitGateErrorRate] [p1:errorRate] below a specified threshold.
+- version: 1.0 
+- comments: Physical gate error rates are a standard measure for the reliablity of executing quantum circuits.
+--- # Configuration data
+- p1:
+  - operator: <
+  - targetValue: 0.0001

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/OneQubitGateErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/OneQubitGateErrorRate.yml
@@ -1,9 +1,11 @@
---- # Metadata
-- id: OneQubitGateErrorRate
-- description: This rule assesses whether a [QPU] has [OneQubitGateErrorRate] [p1:errorRate] below a specified threshold.
-- version: 1.0 
-- comments: Physical gate error rates are a standard measure for the reliablity of executing quantum circuits.
---- # Configuration data
-- p1:
-  - operator: <
-  - targetValue: 0.0001
+# Metadata
+id: OneQubitGateErrorRate
+description: This rule assesses whether a [QPU] has [OneQubitGateErrorRate] [p1:errorRate] below a specified threshold.
+version: 1.0 
+comments: Physical gate error rates are a standard measure for the reliability of executing quantum circuits.
+--- 
+# Configuration data
+configuration:
+  p1:
+    operator: <
+    targetValue: 0.0001

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/OneQubitGateErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/OneQubitGateErrorRate.yml
@@ -1,6 +1,6 @@
 # Metadata
 id: OneQubitGateErrorRate
-description: This rule assesses whether a [QPU] has [OneQubitGateErrorRate] [p1:errorRate] below a specified threshold.
+description: This rule assesses whether a [QPU] has a [OneQubitGateErrorRate] that is below a specified [p1:errorRate] threshold.
 version: 1.0 
 comments: Physical gate error rates are a standard measure for the reliability of executing quantum circuits.
 --- 

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/data.json
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/data.json
@@ -1,0 +1,4 @@
+{
+    "operator" : "<",
+    "target_value" : 0.0001
+}

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
@@ -1,6 +1,7 @@
 package cch.metrics.one_qubit_gate_error_rate
 
 import data.cch.compare
+import rego.v1
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
@@ -1,6 +1,6 @@
-package metrics.quantum.reliability
+package cch.metrics.one_qubit_gate_error_rate
 
-import data.compare
+import data.cch.compare
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
@@ -1,0 +1,15 @@
+package metrics.quantum.reliability
+
+import data.compare
+
+default applicable = false
+
+default compliant = false
+
+applicable if {
+	input.OneQubitGateErrorRate
+}
+
+compliant if {
+	compare(data.operator, data.target_value, input.OneQubitGateErrorRate)
+}

--- a/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/OneQubitGateErrorRate/metric.rego
@@ -8,7 +8,7 @@ default applicable = false
 default compliant = false
 
 applicable if {
-	input.OneQubitGateErrorRate
+	input.type[_] == "QPU"
 }
 
 compliant if {

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/SPAMErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/SPAMErrorRate.yml
@@ -1,0 +1,9 @@
+--- # Metadata
+- id: SPAMErrorRate
+- description: This rule assesses whether a [QPU] has [SPAMErrorRate] [p1:errorRate] below a specified threshold.
+- version: 1.0 
+- comments: State preparation and measuremnet (SPAM) error rates are a standard measure for the reliablity of readout of the results for a quantum circuit.
+--- # Configuration data
+- p1:
+  - operator: <
+  - targetValue: 0.0001

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/SPAMErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/SPAMErrorRate.yml
@@ -1,6 +1,6 @@
 # Metadata
 id: SPAMErrorRate
-description: This rule assesses whether a [QPU] has [SPAMErrorRate] [p1:errorRate] below a specified threshold.
+description: This rule assesses whether a [QPU] has a [SPAMErrorRate] that is below a specified [p1:errorRate] threshold.
 version: 1.0 
 comments: State preparation and measuremnet (SPAM) error rates are a standard measure for the reliability of readout of the results for a quantum circuit.
 --- 

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/SPAMErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/SPAMErrorRate.yml
@@ -1,9 +1,11 @@
---- # Metadata
-- id: SPAMErrorRate
-- description: This rule assesses whether a [QPU] has [SPAMErrorRate] [p1:errorRate] below a specified threshold.
-- version: 1.0 
-- comments: State preparation and measuremnet (SPAM) error rates are a standard measure for the reliablity of readout of the results for a quantum circuit.
---- # Configuration data
-- p1:
-  - operator: <
-  - targetValue: 0.0001
+# Metadata
+id: SPAMErrorRate
+description: This rule assesses whether a [QPU] has [SPAMErrorRate] [p1:errorRate] below a specified threshold.
+version: 1.0 
+comments: State preparation and measuremnet (SPAM) error rates are a standard measure for the reliability of readout of the results for a quantum circuit.
+--- 
+# Configuration data
+configuration:
+  p1:
+    operator: <
+    targetValue: 0.0001

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/data.json
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/data.json
@@ -1,0 +1,4 @@
+{
+    "operator" : "<",
+    "target_value" : 0.0001
+}

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
@@ -1,0 +1,15 @@
+package metrics.quantum.reliability
+
+import data.compare
+
+default applicable = false
+
+default compliant = false
+
+applicable if {
+	input.SPAMErrorRate
+}
+
+compliant if {
+	compare(data.operator, data.target_value, input.SPAMErrorRate)
+}

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
@@ -1,6 +1,7 @@
 package cch.metrics.quantum_spam_error_rate
 
 import data.cch.compare
+import rego.v1
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
@@ -1,6 +1,6 @@
-package metrics.quantum.reliability
+package cch.metrics.quantum_spam_error_rate
 
-import data.compare
+import data.cch.compare
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/SPAMErrorRate/metric.rego
@@ -8,7 +8,7 @@ default applicable = false
 default compliant = false
 
 applicable if {
-	input.SPAMErrorRate
+	input.type[_] == "QPU"
 }
 
 compliant if {

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/TwoQubitGateErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/TwoQubitGateErrorRate.yml
@@ -1,9 +1,11 @@
---- # Metadata
-- id: TwoQubitGateErrorRate
-- description: This rule assesses whether a [QPU] has [TwoQubitGateErrorRate] [p1:errorRate] below a specified threshold.
-- version: 1.0 
-- comments: Physical gate error rates are a standard measure for the reliablity of executing quantum circuits.
---- # Configuration data
-- p1:
-  - operator: <
-  - targetValue: 0.0001
+# Metadata
+id: TwoQubitGateErrorRate
+description: This rule assesses whether a [QPU] has [TwoQubitGateErrorRate] [p1:errorRate] below a specified threshold.
+version: 1.0 
+comments: Physical gate error rates are a standard measure for the reliability of executing quantum circuits.
+--- 
+# Configuration data
+configuration:
+  p1:
+    operator: <
+    targetValue: 0.0001

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/TwoQubitGateErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/TwoQubitGateErrorRate.yml
@@ -1,0 +1,9 @@
+--- # Metadata
+- id: TwoQubitGateErrorRate
+- description: This rule assesses whether a [QPU] has [TwoQubitGateErrorRate] [p1:errorRate] below a specified threshold.
+- version: 1.0 
+- comments: Physical gate error rates are a standard measure for the reliablity of executing quantum circuits.
+--- # Configuration data
+- p1:
+  - operator: <
+  - targetValue: 0.0001

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/TwoQubitGateErrorRate.yml
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/TwoQubitGateErrorRate.yml
@@ -1,6 +1,6 @@
 # Metadata
 id: TwoQubitGateErrorRate
-description: This rule assesses whether a [QPU] has [TwoQubitGateErrorRate] [p1:errorRate] below a specified threshold.
+description: This rule assesses whether a [QPU] has a [TwoQubitGateErrorRate] that is below a specified [p1:errorRate] threshold.
 version: 1.0 
 comments: Physical gate error rates are a standard measure for the reliability of executing quantum circuits.
 --- 

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/data.json
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/data.json
@@ -1,0 +1,4 @@
+{
+    "operator" : "<",
+    "target_value" : 0.0001
+}

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
@@ -8,7 +8,7 @@ default applicable = false
 default compliant = false
 
 applicable if {
-	input.TwoQubitGateErrorRate
+	input.type[_] == "QPU"
 }
 
 compliant if {

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
@@ -1,6 +1,6 @@
-package metrics.quantum.reliability
+package cch.metrics.two_qubit_error_rate
 
-import data.compare
+import data.cch.compare
 
 default applicable = false
 

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
@@ -1,0 +1,15 @@
+package metrics.quantum.reliability
+
+import data.compare
+
+default applicable = false
+
+default compliant = false
+
+applicable if {
+	input.TwoQubitGateErrorRate
+}
+
+compliant if {
+	compare(data.operator, data.target_value, input.TwoQubitGateErrorRate)
+}

--- a/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
+++ b/metrics/QuantumSecurity/Reliability/TwoQubitGateErrorRate/metric.rego
@@ -1,6 +1,7 @@
 package cch.metrics.two_qubit_error_rate
 
 import data.cch.compare
+import rego.v1
 
 default applicable = false
 


### PR DESCRIPTION
Added initial metrics assessing the reliability a QPU:
OneQubitGateErrorRate
TwoQubitGateErrorRate
SPAMErrorRate
ErrorCorrectionEnabled