### PR TITLE
Fix TlsDHGroup metric ID

### DIFF
--- a/metrics/TransportEncryption/TlsDHGroup/TlsDHGroup.yaml
+++ b/metrics/TransportEncryption/TlsDHGroup/TlsDHGroup.yaml
@@ -1,5 +1,5 @@
 # ====== Metadata ======
-id: TlsDhGroup
+id: TlsDHGroup
 description: This rule assesses whether a [Resource] has its [TransportEncryption] [p1:dhGroups] correctly configured.
 category: TransportEncryption
 version: "1.0"


### PR DESCRIPTION
This PR fixes the TlsDHGroup metric ID which does not conform to the folder and file name