### PR TITLE
User number instead of integer to allow for float

### DIFF
--- a/metric_schema.json
+++ b/metric_schema.json
@@ -58,7 +58,7 @@
           },
           "targetValue": {
             "type": [
-              "integer",
+              "number",
               "string",
               "boolean",
               "array"


### PR DESCRIPTION
This PR adjusts the json schema to allow for float values. It just replaces "integer" with "number" since the latter allows for both integers and float, see https://json-schema.org/understanding-json-schema/reference/numeric#number