### PR TITLE
Metrics: Fix Amoe metric MonitoringReviewFrequency

### DIFF
--- a/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
+++ b/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: "d0f6a13b-e742-42ff-bf69-9ee077be3b42"
 name: "MonitoringReviewFrequency"
-description: "This rule assesses whether a [PolicyDocument] has a [Governance] entity containing [MonitoringProcedure] with [p1:intervalMonths] set correctly."
+description: "This rule assesses whether a [PolicyDocument] includes [Governance.MonitoringProcedure] with [p1:intervalMonths] set correctly."
 implementationGuidelines:
   AMOE:
     previous_name: MonitoringReviewFrequencyQ3

--- a/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
+++ b/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: "d0f6a13b-e742-42ff-bf69-9ee077be3b42"
 name: "MonitoringReviewFrequency"
-description: "This rule assesses whether a [PolicyDocument] includes [MonitoringProcedure] with [p1:intervalMonths] set correctly."
+description: "This rule assesses whether a [PolicyDocument] has [MonitoringProcedure] with [p1:intervalMonths] set correctly."
 implementationGuidelines:
   AMOE:
     previous_name: MonitoringReviewFrequencyQ3

--- a/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
+++ b/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: "d0f6a13b-e742-42ff-bf69-9ee077be3b42"
 name: "MonitoringReviewFrequency"
-description: "This rule assesses whether a [PolicyDocument] has [MonitoringProcedure] with [p1:intervalMonths] set correctly."
+description: "This rule assesses whether a [PolicyDocument] has a [Governance] entity containing [MonitoringProcedure] with [p1:intervalMonths] set correctly."
 implementationGuidelines:
   AMOE:
     previous_name: MonitoringReviewFrequencyQ3

--- a/metrics/Governance/MonitoringReviewFrequency/metric.rego
+++ b/metrics/Governance/MonitoringReviewFrequency/metric.rego
@@ -12,7 +12,7 @@ applicable if {
 }
 
 compliant if {
-	compare(data.operator, data.target_value, document.governance.monitoringProcedure.intervalMonths)
+	compare(data.operator, data.target_value, document.monitoringProcedure.intervalMonths)
 }
 
 message := "Monitoring procedures are reviewed frequently enough to ensure compliance." if {

--- a/metrics/Governance/MonitoringReviewFrequency/metric.rego
+++ b/metrics/Governance/MonitoringReviewFrequency/metric.rego
@@ -2,17 +2,18 @@ package cch.metrics.monitoring_review_frequency
 
 import data.cch.compare
 import rego.v1
-import input as document
+import input.governance as governance
 
 default applicable := false
 default compliant := false
 
 applicable if {
-	"PolicyDocument" in document.type
+	governance
+	"PolicyDocument" in input.type
 }
 
 compliant if {
-	compare(data.operator, data.target_value, document.monitoringProcedure.intervalMonths)
+	compare(data.operator, data.target_value, governance.monitoringProcedure.intervalMonths)
 }
 
 message := "Monitoring procedures are reviewed frequently enough to ensure compliance." if {

--- a/ontology/v1/catalog-v001.xml
+++ b/ontology/v1/catalog-v001.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
     </group>
 </catalog>

--- a/ontology/v1/catalog-v001.xml
+++ b/ontology/v1/catalog-v001.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776171987430" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
     </group>
 </catalog>

--- a/ontology/v1/catalog-v001.xml
+++ b/ontology/v1/catalog-v001.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
     </group>
 </catalog>

--- a/ontology/v1/catalog-v001.xml
+++ b/ontology/v1/catalog-v001.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1775656055484" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1774447594212" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
     </group>
 </catalog>

--- a/ontology/v1/catalog-v001.xml
+++ b/ontology/v1/catalog-v001.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776759714607" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
     </group>
 </catalog>

--- a/ontology/v1/catalog-v001.xml
+++ b/ontology/v1/catalog-v001.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
-        <uri id="Automatically generated entry, Timestamp=1776172289121" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology-merged.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="duplicate:https://ontology.cybersecuritycertcluster.eu" uri="ontology.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core" uri="core.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/evidence" uri="core/evidence.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/framework" uri="core/framework.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/functionality" uri="core/functionality.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/properties" uri="core/properties.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/resource" uri="core/resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/core/security" uri="core/security.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/data" uri="data.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource" uri="resource.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/application" uri="resource/application.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/document" uri="resource/document.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/governance" uri="resource/governance.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/hardware" uri="resource/hardware.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/infrastructure" uri="resource/infrastructure.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/ml" uri="resource/ml.owx"/>
+        <uri id="Automatically generated entry, Timestamp=1776174336604" name="https://ontology.cybersecuritycertcluster.eu/resource/product" uri="resource/product.owx"/>
     </group>
 </catalog>

--- a/ontology/v1/core/functionality.owx
+++ b/ontology/v1/core/functionality.owx
@@ -212,6 +212,9 @@
         <Class abbreviatedIRI="core:Time"/>
     </Declaration>
     <Declaration>
+        <Class abbreviatedIRI="core:MonitoringProcedure"/>
+    </Declaration>
+    <Declaration>
         <Class abbreviatedIRI="core:CipherSuite"/>
     </Declaration>
     <Declaration>
@@ -1287,6 +1290,10 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:Functionality"/>
         <Class abbreviatedIRI="owl:Thing"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="core:MonitoringProcedure"/>
+        <Class abbreviatedIRI="core:Functionality"/>
     </SubClassOf>
     <SubClassOf>
         <Class abbreviatedIRI="core:HashOperation"/>

--- a/ontology/v1/core/functionality.owx
+++ b/ontology/v1/core/functionality.owx
@@ -212,9 +212,6 @@
         <Class abbreviatedIRI="core:Time"/>
     </Declaration>
     <Declaration>
-        <Class abbreviatedIRI="core:MonitoringProcedure"/>
-    </Declaration>
-    <Declaration>
         <Class abbreviatedIRI="core:CipherSuite"/>
     </Declaration>
     <Declaration>
@@ -1290,10 +1287,6 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:Functionality"/>
         <Class abbreviatedIRI="owl:Thing"/>
-    </SubClassOf>
-    <SubClassOf>
-        <Class abbreviatedIRI="core:MonitoringProcedure"/>
-        <Class abbreviatedIRI="core:Functionality"/>
     </SubClassOf>
     <SubClassOf>
         <Class abbreviatedIRI="core:HashOperation"/>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1470,9 +1470,6 @@
         <DataProperty IRI="/classes//mode"/>
     </Declaration>
     <Declaration>
-        <ObjectProperty IRI="/properties/offersInterface"/>
-    </Declaration>
-    <Declaration>
         <ObjectProperty IRI="/classes/describes"/>
     </Declaration>
     <Declaration>
@@ -3990,7 +3987,7 @@
     <SubClassOf>
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty IRI="/properties/offersInterface"/>
+            <ObjectProperty IRI="/properties/hasMultiple"/>
             <Class IRI="/classes/Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1470,6 +1470,9 @@
         <DataProperty IRI="/classes//mode"/>
     </Declaration>
     <Declaration>
+        <ObjectProperty IRI="/properties/offersInterface"/>
+    </Declaration>
+    <Declaration>
         <ObjectProperty IRI="/classes/describes"/>
     </Declaration>
     <Declaration>
@@ -2798,7 +2801,7 @@
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/Governance"/>
-        <Class IRI="/classes/Resource"/>
+        <Class IRI="/classes/Functionality"/>
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/Hardware"/>
@@ -3747,7 +3750,7 @@
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/MonitoringProcedure"/>
-        <Class IRI="/classes/Functionality"/>
+        <Class IRI="/classes/Governance"/>
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/MonitoringProcedure"/>
@@ -3987,8 +3990,8 @@
     <SubClassOf>
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty IRI="/properties/has"/>
-            <Class IRI="/classes/MonitoringProcedure"/>
+            <ObjectProperty IRI="/properties/offersInterface"/>
+            <Class IRI="/classes/Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
@@ -6082,7 +6085,7 @@ name = metadata.name</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="rdfs:comment"/>
         <IRI>/classes/Governance</IRI>
-        <Literal>Governance represents organizational security management artifacts (e.g., trainings and responsible contacts) that are often evidenced via documents.</Literal>
+        <Literal>Governance represents organizational security management artifacts (e.g., procedures and trainings) that are often evidenced via documents.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1470,9 +1470,6 @@
         <DataProperty IRI="/classes//mode"/>
     </Declaration>
     <Declaration>
-        <ObjectProperty IRI="/properties/offersInterface"/>
-    </Declaration>
-    <Declaration>
         <ObjectProperty IRI="/classes/describes"/>
     </Declaration>
     <Declaration>
@@ -3750,7 +3747,7 @@
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/MonitoringProcedure"/>
-        <Class IRI="/classes/Governance"/>
+        <Class IRI="/classes/Functionality"/>
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/MonitoringProcedure"/>
@@ -3990,8 +3987,8 @@
     <SubClassOf>
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty IRI="/properties/offersInterface"/>
-            <Class IRI="/classes/Governance"/>
+            <ObjectProperty IRI="/properties/has"/>
+            <Class IRI="/classes/MonitoringProcedure"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
@@ -6085,7 +6082,7 @@ name = metadata.name</Literal>
     <AnnotationAssertion>
         <AnnotationProperty IRI="rdfs:comment"/>
         <IRI>/classes/Governance</IRI>
-        <Literal>Governance represents organizational security management artifacts (e.g., procedures and trainings) that are often evidenced via documents.</Literal>
+        <Literal>Governance represents organizational security management artifacts (e.g., trainings and responsible contacts) that are often evidenced via documents.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -3987,7 +3987,7 @@
     <SubClassOf>
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty IRI="/properties/hasMultiple"/>
+            <ObjectProperty IRI="/properties/has"/>
             <Class IRI="/classes/Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -3987,7 +3987,7 @@
     <SubClassOf>
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty IRI="/properties/has"/>
+            <ObjectProperty IRI="/properties/hasMultiple"/>
             <Class IRI="/classes/Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -3209,7 +3209,7 @@ message PolicyDocument {
 	repeated CryptographicHash cryptographic_hashs  = 12896;
 	DataLocation data_location = 11474;
 	repeated DocumentSignature document_signatures  = 7191;
-	repeated Governance governances  = 4759;
+	Governance governance = 18871;
 	optional string parent_id = 18208;
 	SchemaValidation validated_by = 5620;
 	repeated SecurityFeature security_features  = 13896;

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -3209,7 +3209,7 @@ message PolicyDocument {
 	repeated CryptographicHash cryptographic_hashs  = 12896;
 	DataLocation data_location = 11474;
 	repeated DocumentSignature document_signatures  = 7191;
-	Governance governance = 18871;
+	repeated Governance governances  = 4759;
 	optional string parent_id = 18208;
 	SchemaValidation validated_by = 5620;
 	repeated SecurityFeature security_features  = 13896;

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -1717,6 +1717,7 @@ message Functionality {
 		Input input = 2243;
 		KeyDerivationFunction key_derivation_function = 2001;
 		MessageAuthenticationCode message_authentication_code = 8921;
+		MonitoringProcedure monitoring_procedure = 11320;
 		Authenticate authenticate = 1798;
 		AuthorizeJwt authorize_jwt = 1893;
 		IssueJwt issue_jwt = 157;
@@ -1853,7 +1854,6 @@ message Governance {
 
 	oneof type {
 		ContactPerson contact_person = 7415;
-		MonitoringProcedure monitoring_procedure = 4844;
 		AwarenessTraining awareness_training = 18321;
 		SecurityTraining security_training = 16425;
 	}
@@ -2784,19 +2784,10 @@ message CodeModule {
 // intervalMonths: Review frequency (in months) for reviewing monitoring procedures
 message MonitoringProcedure {
 	option (resource_type_names) = "MonitoringProcedure";
-	option (resource_type_names) = "Governance";
-	option (resource_type_names) = "Resource";
+	option (resource_type_names) = "Functionality";
 
-	google.protobuf.Timestamp creation_time = 13504;
-	string description = 17881;
-	string id = 11072 [ (buf.validate.field).required = true ];
 	// The interval refers to the interval in months.
-	int32 interval_months = 5083;
-	map<string, string> labels = 9724;
-	string name = 6599 [ (buf.validate.field).required = true ];
-	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	string raw = 5928;
-	optional string parent_id = 18171;
+	int32 interval_months = 6177;
 }
 
 // MultiFactorAuthentiation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -3229,7 +3220,7 @@ message PolicyDocument {
 	repeated CryptographicHash cryptographic_hashs  = 12896;
 	DataLocation data_location = 11474;
 	repeated DocumentSignature document_signatures  = 7191;
-	optional string governance_id = 15049;
+	MonitoringProcedure monitoring_procedure = 11357;
 	optional string parent_id = 18208;
 	SchemaValidation validated_by = 5620;
 	repeated SecurityFeature security_features  = 13896;
@@ -3681,7 +3672,6 @@ message Resource {
 		Token token = 5266;
 		Value value = 652;
 		ContactPerson contact_person = 7415;
-		MonitoringProcedure monitoring_procedure = 4844;
 		AwarenessTraining awareness_training = 18321;
 		SecurityTraining security_training = 16425;
 		Memory memory = 967;

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -3209,7 +3209,7 @@ message PolicyDocument {
 	repeated CryptographicHash cryptographic_hashs  = 12896;
 	DataLocation data_location = 11474;
 	repeated DocumentSignature document_signatures  = 7191;
-	Governance governance = 15049;
+	repeated Governance governances  = 4759;
 	optional string parent_id = 18208;
 	SchemaValidation validated_by = 5620;
 	repeated SecurityFeature security_features  = 13896;

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -345,18 +345,10 @@ message AwarenessTraining {
 	option (resource_type_names) = "AwarenessTraining";
 	option (resource_type_names) = "Training";
 	option (resource_type_names) = "Governance";
-	option (resource_type_names) = "Resource";
+	option (resource_type_names) = "Functionality";
 
-	bool annual_update_completed = 5546;
-	google.protobuf.Timestamp creation_time = 6371;
-	string description = 1978;
-	string id = 10258 [ (buf.validate.field).required = true ];
-	map<string, string> labels = 7290;
-	string name = 8381 [ (buf.validate.field).required = true ];
-	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	string raw = 3963;
-	bool successfully_completed_percentage = 832;
-	optional string parent_id = 17698;
+	bool annual_update_completed = 4205;
+	bool successfully_completed_percentage = 9380;
 }
 
 // Backup is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -821,19 +813,11 @@ message ConfigurationSource {
 message ContactPerson {
 	option (resource_type_names) = "ContactPerson";
 	option (resource_type_names) = "Governance";
-	option (resource_type_names) = "Resource";
+	option (resource_type_names) = "Functionality";
 
-	google.protobuf.Timestamp creation_time = 15387;
-	string description = 16050;
-	string email_address = 8616;
-	string id = 10681 [ (buf.validate.field).required = true ];
-	string job_title = 8334;
-	map<string, string> labels = 11792;
-	string name = 8652 [ (buf.validate.field).required = true ];
-	string phone_number = 10029;
-	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	string raw = 11703;
-	optional string parent_id = 11554;
+	string email_address = 15629;
+	string job_title = 6896;
+	string phone_number = 13203;
 }
 
 // Container is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -1710,6 +1694,10 @@ message Functionality {
 		Main main = 1117;
 		HttpEndpoint http_endpoint = 8995;
 		Error error = 6544;
+		ContactPerson contact_person = 1620;
+		MonitoringProcedure monitoring_procedure = 9388;
+		AwarenessTraining awareness_training = 8227;
+		SecurityTraining security_training = 8543;
 		HttpClient http_client = 18121;
 		HttpRequestContext http_request_context = 4279;
 		HttpRequestHandler http_request_handler = 147;
@@ -1717,7 +1705,6 @@ message Functionality {
 		Input input = 2243;
 		KeyDerivationFunction key_derivation_function = 2001;
 		MessageAuthenticationCode message_authentication_code = 8921;
-		MonitoringProcedure monitoring_procedure = 11320;
 		Authenticate authenticate = 1798;
 		AuthorizeJwt authorize_jwt = 1893;
 		IssueJwt issue_jwt = 157;
@@ -1853,9 +1840,10 @@ message GetSecret {
 message Governance {
 
 	oneof type {
-		ContactPerson contact_person = 7415;
-		AwarenessTraining awareness_training = 18321;
-		SecurityTraining security_training = 16425;
+		ContactPerson contact_person = 1620;
+		MonitoringProcedure monitoring_procedure = 9388;
+		AwarenessTraining awareness_training = 8227;
+		SecurityTraining security_training = 8543;
 	}
 }
 
@@ -2784,10 +2772,11 @@ message CodeModule {
 // intervalMonths: Review frequency (in months) for reviewing monitoring procedures
 message MonitoringProcedure {
 	option (resource_type_names) = "MonitoringProcedure";
+	option (resource_type_names) = "Governance";
 	option (resource_type_names) = "Functionality";
 
 	// The interval refers to the interval in months.
-	int32 interval_months = 6177;
+	int32 interval_months = 13218;
 }
 
 // MultiFactorAuthentiation is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -3220,7 +3209,7 @@ message PolicyDocument {
 	repeated CryptographicHash cryptographic_hashs  = 12896;
 	DataLocation data_location = 11474;
 	repeated DocumentSignature document_signatures  = 7191;
-	MonitoringProcedure monitoring_procedure = 11357;
+	Governance governance = 15049;
 	optional string parent_id = 18208;
 	SchemaValidation validated_by = 5620;
 	repeated SecurityFeature security_features  = 13896;
@@ -3281,9 +3270,9 @@ message Product {
 	google.protobuf.Timestamp support_ends = 14253;
 	string type = 6467;
 	repeated string code_ids  = 10540;
-	optional string contact_person_id = 8641;
+	ContactPerson contact_person = 8641;
 	repeated string data_ids  = 11462;
-	repeated string governance_ids  = 16685;
+	repeated Governance governances  = 16685;
 	repeated string hardware_ids  = 7586;
 	repeated string infrastructure_ids  = 2977;
 	optional string parent_id = 715;
@@ -3671,9 +3660,6 @@ message Resource {
 		AndRule and_rule = 1114;
 		Token token = 5266;
 		Value value = 652;
-		ContactPerson contact_person = 7415;
-		AwarenessTraining awareness_training = 18321;
-		SecurityTraining security_training = 16425;
 		Memory memory = 967;
 		Product product = 7503;
 		Application application = 18554;
@@ -3952,18 +3938,10 @@ message SecurityTraining {
 	option (resource_type_names) = "SecurityTraining";
 	option (resource_type_names) = "Training";
 	option (resource_type_names) = "Governance";
-	option (resource_type_names) = "Resource";
+	option (resource_type_names) = "Functionality";
 
-	bool annual_update_completed = 12324;
-	google.protobuf.Timestamp creation_time = 2973;
-	string description = 16969;
-	string id = 16887 [ (buf.validate.field).required = true ];
-	map<string, string> labels = 15328;
-	string name = 2030 [ (buf.validate.field).required = true ];
-	// The raw field contains the raw information that is used to fill in the fields of the ontology.
-	string raw = 11220;
-	bool successfully_completed_percentage = 11821;
-	optional string parent_id = 10643;
+	bool annual_update_completed = 10890;
+	bool successfully_completed_percentage = 18938;
 }
 
 // ServiceMetadataDocument is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
@@ -4121,8 +4099,8 @@ message Token {
 message Training {
 
 	oneof type {
-		AwarenessTraining awareness_training = 18321;
-		SecurityTraining security_training = 16425;
+		AwarenessTraining awareness_training = 8227;
+		SecurityTraining security_training = 8543;
 	}
 }
 

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -411,7 +411,7 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty abbreviatedIRI="prop:has"/>
+            <ObjectProperty abbreviatedIRI="prop:hasMultiple"/>
             <Class abbreviatedIRI="core:Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -411,8 +411,8 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty abbreviatedIRI="prop:offersInterface"/>
-            <Class abbreviatedIRI="core:Governance"/>
+            <ObjectProperty abbreviatedIRI="prop:has"/>
+            <Class abbreviatedIRI="core:MonitoringProcedure"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -411,8 +411,8 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty abbreviatedIRI="prop:has"/>
-            <Class abbreviatedIRI="core:MonitoringProcedure"/>
+            <ObjectProperty abbreviatedIRI="prop:offersInterface"/>
+            <Class abbreviatedIRI="core:Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -411,7 +411,7 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty abbreviatedIRI="prop:hasMultiple"/>
+            <ObjectProperty abbreviatedIRI="prop:has"/>
             <Class abbreviatedIRI="core:Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -411,7 +411,7 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:PolicyDocument"/>
         <ObjectSomeValuesFrom>
-            <ObjectProperty abbreviatedIRI="prop:offersInterface"/>
+            <ObjectProperty abbreviatedIRI="prop:hasMultiple"/>
             <Class abbreviatedIRI="core:Governance"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/resource/governance.owx
+++ b/ontology/v1/resource/governance.owx
@@ -40,7 +40,7 @@
     </SubClassOf>
     <SubClassOf>
         <Class abbreviatedIRI="res:Governance"/>
-        <Class abbreviatedIRI="core:Resource"/>
+        <Class abbreviatedIRI="core:Functionality"/>
     </SubClassOf>
     <SubClassOf>
         <Class abbreviatedIRI="res:SecurityTraining"/>

--- a/ontology/v1/resource/governance.owx
+++ b/ontology/v1/resource/governance.owx
@@ -47,6 +47,10 @@
         <Class abbreviatedIRI="res:Training"/>
     </SubClassOf>
     <SubClassOf>
+        <Class abbreviatedIRI="res:MonitoringProcedure"/>
+        <Class abbreviatedIRI="res:Governance"/>
+    </SubClassOf>
+    <SubClassOf>
         <Class abbreviatedIRI="res:Training"/>
         <Class abbreviatedIRI="res:Governance"/>
     </SubClassOf>
@@ -99,7 +103,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="rdfs:comment"/>
         <AbbreviatedIRI>core:Governance</AbbreviatedIRI>
-        <Literal>Governance represents organizational security management artifacts (e.g., trainings and responsible contacts) that are often evidenced via documents.</Literal>
+        <Literal>Governance represents organizational security management artifacts (e.g., procedures and trainings) that are often evidenced via documents.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/ontology/v1/resource/governance.owx
+++ b/ontology/v1/resource/governance.owx
@@ -47,10 +47,6 @@
         <Class abbreviatedIRI="res:Training"/>
     </SubClassOf>
     <SubClassOf>
-        <Class abbreviatedIRI="res:MonitoringProcedure"/>
-        <Class abbreviatedIRI="res:Governance"/>
-    </SubClassOf>
-    <SubClassOf>
         <Class abbreviatedIRI="res:Training"/>
         <Class abbreviatedIRI="res:Governance"/>
     </SubClassOf>
@@ -103,7 +99,7 @@
     <AnnotationAssertion>
         <AnnotationProperty IRI="rdfs:comment"/>
         <AbbreviatedIRI>core:Governance</AbbreviatedIRI>
-        <Literal>Governance represents organizational security management artifacts (e.g., procedures and trainings) that are often evidenced via documents.</Literal>
+        <Literal>Governance represents organizational security management artifacts (e.g., trainings and responsible contacts) that are often evidenced via documents.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>


### PR DESCRIPTION
Before, Governance was referenced in a policy document. This had the side effect that the evidence collector (in this case, AMOE) would have to create a Governance instance as well which is not preferred.

Now MonitoringProcedure is modeled as functionality and a policy document simply "has" it.
