### PR TITLE
ApprovedCommitAuthorEnforced Fix in Ontology and Rego

### DIFF
--- a/metrics/DevelopmentLifeCycle/ApprovedCommitAuthorEnforced/metric.rego
+++ b/metrics/DevelopmentLifeCycle/ApprovedCommitAuthorEnforced/metric.rego
@@ -9,10 +9,10 @@ default applicable = false
 default compliant = false
 
 applicable if {
-	# we are only interested in code repositories
-	repo
+    repo
+    "CodeRepository" in input.type
 }
 
 compliant if {
-	compare(data.operator, data.target_value, repo.approvedCommitAuthorEnforced)
+    compare(data.operator, data.target_value, repo.approvedCommitAuthorEnforced)
 }

--- a/ontology/v1/resource/infrastructure.owx
+++ b/ontology/v1/resource/infrastructure.owx
@@ -449,6 +449,13 @@
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
+        <Class abbreviatedIRI="cl:CodeRepository"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="prop:approvedCommitAuthorEnforced"/>
+            <Datatype abbreviatedIRI="xsd:boolean"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
         <Class abbreviatedIRI="cl:CloudResource"/>
         <ObjectSomeValuesFrom>
             <ObjectProperty abbreviatedIRI="prop:offers"/>
@@ -1540,15 +1547,20 @@ name = metadata.name</Literal>
         <Literal>CodeRepository</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
-            <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-            <AbbreviatedIRI>cl:CodeRepository</AbbreviatedIRI>
-            <Literal>ReviewPercentage is the percentage of merged pull requests with code reviews.</Literal>
-        </AnnotationAssertion>
-        <AnnotationAssertion>
-            <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
-            <AbbreviatedIRI>cl:CodeRepository</AbbreviatedIRI>
-            <Literal>ReviewPercentageLastMonth is the percentage of merged pull requests with code reviews in the last 30 days.</Literal>
-        </AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>cl:CodeRepository</AbbreviatedIRI>
+        <Literal>ReviewPercentage is the percentage of merged pull requests with code reviews.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>cl:CodeRepository</AbbreviatedIRI>
+        <Literal>ReviewPercentageLastMonth is the percentage of merged pull requests with code reviews in the last 30 days.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>cl:CodeRepository</AbbreviatedIRI>
+        <Literal>ApprovedCommitAuthorEnforced verifies that code modifications are made by authorized developers whose changes have been validated, enhancing accountability and traceability.</Literal>
+    </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <AbbreviatedIRI>cl:Compute</AbbreviatedIRI>


### PR DESCRIPTION
fix: added ApprovedCommitAuthorEnforced metric to ontology and fixed rego

- Declared prop:approvedCommitAuthorEnforced as DataProperty (xsd:boolean)
- Added SubClassOf constraint to cl:CodeRepository
- Added rdfs:comment annotation for the property
- Added "CodeRepository" in input.type guard to applicable rule
