### PR TITLE
metric: Fix `TransportEncryptionEnforced`

### DIFF
--- a/metrics/TransportEncryption/TransportEncryptionEnforced/metric.rego
+++ b/metrics/TransportEncryption/TransportEncryptionEnforced/metric.rego
@@ -13,5 +13,5 @@ applicable if {
 }
 
 compliant if {
-	compare(data.operator, data.target_value, enc[_].enforced)
+	compare(data.operator, data.target_value, enc.enforced)
 }


### PR DESCRIPTION
This PR fixes the rego file for the metric `TransportEncryptionEnforced`. It checks the property `enforced` of an array of `transportEncryption` objects, but `transportEncryption` in only one object and no array. 