### PR TITLE
fix metric categories for sdn metrics

### DIFF
--- a/metrics/NetworkSecurity/DataConfidentialitySDNPolicyPresence/DataConfidentialitySDNPolicyPresence.yaml
+++ b/metrics/NetworkSecurity/DataConfidentialitySDNPolicyPresence/DataConfidentialitySDNPolicyPresence.yaml
@@ -9,7 +9,7 @@ implementationGuidelines:
     is_headline_based: true
     keywords: []
 
-category: "Software Defined Networking"
+category: "NetworkSecurity"
 version: "v1"
 comments: "This metric assesses if Data Confidentiality in SDN is described. Measured in boolean."
 

--- a/metrics/NetworkSecurity/SDNFunctionValidationPolicyPresence/SDNFunctionValidationPolicyPresence.yaml
+++ b/metrics/NetworkSecurity/SDNFunctionValidationPolicyPresence/SDNFunctionValidationPolicyPresence.yaml
@@ -9,7 +9,7 @@ implementationGuidelines:
     is_headline_based: true
     keywords: []
 
-category: "Software Defined Networking"
+category: "NetworkSecurity"
 version: "v1"
 comments: "This metric assesses if Validation & Testing of SDN Functions is described. Measured in boolean."
 


### PR DESCRIPTION
This PR fixes two metric category names to "NetworkSecurity" such that tools like Confirmate correctly find their implementations.
