### PR TITLE
Fix missing AMOE ontology properties and MonitoringReviewFrequency metric

### DIFF
--- a/metrics/AssetManagement/AssetInventoryEnabled/AssetInventoryEnabled.yaml
+++ b/metrics/AssetManagement/AssetInventoryEnabled/AssetInventoryEnabled.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: "fec3bdbe-b53a-4ffe-a334-2e01a86aa054"
 name: "AssetInventoryEnabled"
-description: "This rule assesses whether a [PolicyDocument] includes [AssetInventory] with [p1:property] set correctly."
+description: "This rule assesses whether a [PolicyDocument] includes [AssetInventory] with [p1:service] set correctly."
 
 implementationGuidelines:
   AMOE:

--- a/metrics/AssetManagement/AssetInventoryEnabled/AssetInventoryEnabled.yaml
+++ b/metrics/AssetManagement/AssetInventoryEnabled/AssetInventoryEnabled.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: "fec3bdbe-b53a-4ffe-a334-2e01a86aa054"
 name: "AssetInventoryEnabled"
-description: "This rule assesses whether a [PolicyDocument] includes [CloudFeature] with [p1:property] set correctly."
+description: "This rule assesses whether a [PolicyDocument] includes [AssetInventory] with [p1:property] set correctly."
 
 implementationGuidelines:
   AMOE:

--- a/metrics/AssetManagement/AssetInventoryEnabled/metric.rego
+++ b/metrics/AssetManagement/AssetInventoryEnabled/metric.rego
@@ -14,7 +14,7 @@ applicable if {
 }
 
 compliant if {
-	compare(data.operator, data.target_value, document.assetInventory.property)
+	compare(data.operator, data.target_value, document.assetInventory.service)
 }
 
 message := "The policy document defines an enabled asset inventory cloud feature." if {

--- a/metrics/AssetManagement/AssetInventoryEnabled/metric.rego
+++ b/metrics/AssetManagement/AssetInventoryEnabled/metric.rego
@@ -9,12 +9,12 @@ default compliant := false
 
 applicable if {
 	document != {}
-	document.cloudFeature
+	document.assetInventory
 	"PolicyDocument" in document.type
 }
 
 compliant if {
-	compare(data.operator, data.target_value, document.cloudFeature.property)
+	compare(data.operator, data.target_value, document.assetInventory.property)
 }
 
 message := "The policy document defines an enabled asset inventory cloud feature." if {

--- a/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
+++ b/metrics/Governance/MonitoringReviewFrequency/MonitoringReviewFrequency.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: "d0f6a13b-e742-42ff-bf69-9ee077be3b42"
 name: "MonitoringReviewFrequency"
-description: "This rule assesses whether a [PolicyDocument] includes [Governance.MonitoringProcedure] with [p1:intervalMonths] set correctly."
+description: "This rule assesses whether a [PolicyDocument] includes [MonitoringProcedure] with [p1:intervalMonths] set correctly."
 implementationGuidelines:
   AMOE:
     previous_name: MonitoringReviewFrequencyQ3

--- a/metrics/Governance/MonitoringReviewFrequency/metric.rego
+++ b/metrics/Governance/MonitoringReviewFrequency/metric.rego
@@ -2,18 +2,18 @@ package cch.metrics.monitoring_review_frequency
 
 import data.cch.compare
 import rego.v1
-import input.governance as governance
+import input.monitoringProcedure as monitoringProcedure
 
 default applicable := false
 default compliant := false
 
 applicable if {
-	governance != {}
+	monitoringProcedure != {}
 	"PolicyDocument" in input.type
 }
 
 compliant if {
-	compare(data.operator, data.target_value, governance.monitoringProcedure.intervalMonths)
+	compare(data.operator, data.target_value, monitoringProcedure.intervalMonths)
 }
 
 message := "Monitoring procedures are reviewed frequently enough to ensure compliance." if {

--- a/ontology/v1/core/properties.owx
+++ b/ontology/v1/core/properties.owx
@@ -151,7 +151,7 @@
         <DataProperty abbreviatedIRI="res:recoveryFrequency"/>
     </Declaration>
     <Declaration>
-        <DataProperty abbreviatedIRI="res:property"/>
+        <DataProperty abbreviatedIRI="res:service"/>
     </Declaration>
     <Declaration>
         <DataProperty abbreviatedIRI="res:team"/>
@@ -688,9 +688,14 @@
         <Literal>recoveryFrequency</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>res:service</AbbreviatedIRI>
+        <Literal>Service contains the name of the service (e.g., Asset Management).</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
-        <AbbreviatedIRI>res:property</AbbreviatedIRI>
-        <Literal>property</Literal>
+        <AbbreviatedIRI>res:service</AbbreviatedIRI>
+        <Literal>service</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>

--- a/ontology/v1/core/security.owx
+++ b/ontology/v1/core/security.owx
@@ -517,7 +517,7 @@
     <SubClassOf>
         <Class abbreviatedIRI="core:AssetInventory"/>
         <DataSomeValuesFrom>
-            <DataProperty abbreviatedIRI="core:property"/>
+            <DataProperty abbreviatedIRI="core:service"/>
             <Datatype abbreviatedIRI="xsd:string"/>
         </DataSomeValuesFrom>
     </SubClassOf>
@@ -1343,6 +1343,11 @@
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <AbbreviatedIRI>core:AssetInventory</AbbreviatedIRI>
         <Literal>Class representing the inventory of assets.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <AbbreviatedIRI>core:AssetInventory</AbbreviatedIRI>
+        <Literal>Service contains the name of the service (e.g., Asset Management).</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/ontology/v1/core/security.owx
+++ b/ontology/v1/core/security.owx
@@ -515,6 +515,13 @@
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
+        <Class abbreviatedIRI="core:AssetInventory"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="core:property"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
         <Class abbreviatedIRI="core:AtRestEncryption"/>
         <Class abbreviatedIRI="core:Encryption"/>
     </SubClassOf>
@@ -663,13 +670,6 @@
         <DataSomeValuesFrom>
             <DataProperty abbreviatedIRI="core:recoveryFrequency"/>
             <Datatype abbreviatedIRI="xsd:int"/>
-        </DataSomeValuesFrom>
-    </SubClassOf>
-    <SubClassOf>
-        <Class abbreviatedIRI="core:CloudFeature"/>
-        <DataSomeValuesFrom>
-            <DataProperty abbreviatedIRI="core:property"/>
-            <Datatype abbreviatedIRI="xsd:string"/>
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>

--- a/ontology/v1/core/security.owx
+++ b/ontology/v1/core/security.owx
@@ -508,6 +508,13 @@
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
+        <Class abbreviatedIRI="core:AssetInventory"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="core:reviewFrequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
         <Class abbreviatedIRI="core:AtRestEncryption"/>
         <Class abbreviatedIRI="core:Encryption"/>
     </SubClassOf>
@@ -643,6 +650,27 @@
             <DataProperty abbreviatedIRI="core:retentionPeriod"/>
             <Literal>xsd:java.time.Duration</Literal>
         </DataHasValue>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="core:Backup"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="core:frequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="core:Backup"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="core:recoveryFrequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="core:CloudFeature"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="core:property"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
         <Class abbreviatedIRI="core:BootLog"/>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1599,9 +1599,6 @@
         <Class IRI="/classes/ConfigurationOperation"/>
     </Declaration>
     <Declaration>
-        <Class IRI="/classes/CloudFeature"/>
-    </Declaration>
-    <Declaration>
         <DataProperty IRI="/classes/TwoQubitErrorRate"/>
     </Declaration>
     <Declaration>
@@ -1795,6 +1792,13 @@
         <DataSomeValuesFrom>
             <DataProperty IRI="/classes/completedReviewPercentage"/>
             <Datatype abbreviatedIRI="xsd:float"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/AssetInventory"/>
+        <DataSomeValuesFrom>
+            <DataProperty IRI="/classes/property"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
@@ -2167,13 +2171,6 @@
         <Class IRI="/classes/CipherSuite"/>
         <DataSomeValuesFrom>
             <DataProperty IRI="/classes/sessionCipher"/>
-            <Datatype abbreviatedIRI="xsd:string"/>
-        </DataSomeValuesFrom>
-    </SubClassOf>
-    <SubClassOf>
-        <Class IRI="/classes/CloudFeature"/>
-        <DataSomeValuesFrom>
-            <DataProperty IRI="/classes/property"/>
             <Datatype abbreviatedIRI="xsd:string"/>
         </DataSomeValuesFrom>
     </SubClassOf>
@@ -4384,13 +4381,6 @@
         <ObjectSomeValuesFrom>
             <ObjectProperty IRI="/properties/has"/>
             <Class IRI="/classes/Backup"/>
-        </ObjectSomeValuesFrom>
-    </SubClassOf>
-    <SubClassOf>
-        <Class IRI="/classes/PolicyDocument"/>
-        <ObjectSomeValuesFrom>
-            <ObjectProperty IRI="/properties/has"/>
-            <Class IRI="/classes/CloudFeature"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1800,6 +1800,13 @@
     <SubClassOf>
         <Class IRI="/classes/AssetInventory"/>
         <DataSomeValuesFrom>
+            <DataProperty IRI="/classes/reviewFrequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/AssetInventory"/>
+        <DataSomeValuesFrom>
             <DataProperty IRI="/properties/auditInterval"/>
             <Datatype abbreviatedIRI="xsd:int"/>
         </DataSomeValuesFrom>
@@ -1992,6 +1999,20 @@
     <SubClassOf>
         <Class IRI="/classes/Backup"/>
         <DataSomeValuesFrom>
+            <DataProperty IRI="/classes/frequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/Backup"/>
+        <DataSomeValuesFrom>
+            <DataProperty IRI="/classes/recoveryFrequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/Backup"/>
+        <DataSomeValuesFrom>
             <DataProperty IRI="/properties/enabled"/>
             <Datatype abbreviatedIRI="xsd:boolean"/>
         </DataSomeValuesFrom>
@@ -2146,6 +2167,13 @@
         <Class IRI="/classes/CipherSuite"/>
         <DataSomeValuesFrom>
             <DataProperty IRI="/classes/sessionCipher"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/CloudFeature"/>
+        <DataSomeValuesFrom>
+            <DataProperty IRI="/classes/property"/>
             <Datatype abbreviatedIRI="xsd:string"/>
         </DataSomeValuesFrom>
     </SubClassOf>
@@ -4341,6 +4369,13 @@
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
             <ObjectProperty IRI="/properties/has"/>
+            <Class IRI="/classes/AccessControlTypePolicy"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/PolicyDocument"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="/properties/has"/>
             <Class IRI="/classes/AssetInventory"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
@@ -4376,7 +4411,21 @@
         <Class IRI="/classes/PolicyDocument"/>
         <ObjectSomeValuesFrom>
             <ObjectProperty IRI="/properties/has"/>
+            <Class IRI="/classes/MonitoringProcedure"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/PolicyDocument"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="/properties/has"/>
             <Class IRI="/classes/NeedToKnowPolicy"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/PolicyDocument"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="/properties/has"/>
+            <Class IRI="/classes/NetworkThreatMitigationPolicy"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>

--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1134,9 +1134,6 @@
         <DataProperty IRI="/classes/programmingVersion"/>
     </Declaration>
     <Declaration>
-        <DataProperty IRI="/classes/property"/>
-    </Declaration>
-    <Declaration>
         <DataProperty IRI="/classes/protocol"/>
     </Declaration>
     <Declaration>
@@ -1189,6 +1186,9 @@
     </Declaration>
     <Declaration>
         <DataProperty IRI="/classes/securityOnly"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="/classes/service"/>
     </Declaration>
     <Declaration>
         <DataProperty IRI="/classes/serviceID"/>
@@ -1797,15 +1797,15 @@
     <SubClassOf>
         <Class IRI="/classes/AssetInventory"/>
         <DataSomeValuesFrom>
-            <DataProperty IRI="/classes/property"/>
-            <Datatype abbreviatedIRI="xsd:string"/>
+            <DataProperty IRI="/classes/reviewFrequency"/>
+            <Datatype abbreviatedIRI="xsd:int"/>
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
         <Class IRI="/classes/AssetInventory"/>
         <DataSomeValuesFrom>
-            <DataProperty IRI="/classes/reviewFrequency"/>
-            <Datatype abbreviatedIRI="xsd:int"/>
+            <DataProperty IRI="/classes/service"/>
+            <Datatype abbreviatedIRI="xsd:string"/>
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
@@ -6012,6 +6012,11 @@ name = metadata.name</Literal>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <IRI>/classes/AssetInventory</IRI>
+        <Literal>Service contains the name of the service (e.g., Asset Management).</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>/classes/AssetInventory</IRI>
         <Literal>Status contains the status of the asset (e.g., active, inactive).</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
@@ -8271,11 +8276,6 @@ name = metadata.name</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
-        <IRI>/classes/property</IRI>
-        <Literal>property</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <IRI>/classes/protects</IRI>
         <Literal>protects</Literal>
     </AnnotationAssertion>
@@ -8393,6 +8393,16 @@ name = metadata.name</Literal>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <IRI>/classes/securityOnly</IRI>
         <Literal>securityOnly</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>/classes/service</IRI>
+        <Literal>Service contains the name of the service (e.g., Asset Management).</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>/classes/service</IRI>
+        <Literal>service</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -233,6 +233,7 @@ message AssetInventory {
 	int32 audit_interval = 15088;
 	// Percentage of completed reviews and updates of asset inventory entries.
 	float completed_review_percentage = 15931;
+	int32 review_frequency = 12717;
 	string status = 11933;
 	string storage_facility = 2637;
 	string type = 11720;
@@ -401,8 +402,10 @@ message Backup {
 	option (resource_type_names) = "SecurityFeature";
 
 	bool enabled = 2815;
+	int32 frequency = 9581;
 	// The interval refers to the update interval in days.
 	google.protobuf.Duration interval = 7186;
+	int32 recovery_frequency = 8809;
 	google.protobuf.Duration retention_period = 6795;
 	optional string storage_id = 17051;
 	TransportEncryption transport_encryption = 2398;
@@ -581,6 +584,7 @@ message CipherSuite {
 message CloudFeature {
 	option (resource_type_names) = "CloudFeature";
 
+	string property = 15213;
 }
 
 // Infrastructure is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
@@ -3422,6 +3426,7 @@ message PolicyDocument {
 	string name = 2052 [ (buf.validate.field).required = true ];
 	// The raw field contains the raw information that is used to fill in the fields of the ontology.
 	string raw = 5038;
+	AccessControlTypePolicy access_control_type_policy = 9164;
 	AssetInventory asset_inventory = 16496;
 	Backup backup = 16402;
 	CloudFeature cloud_feature = 1878;
@@ -3431,7 +3436,9 @@ message PolicyDocument {
 	repeated DocumentSignature document_signatures  = 7191;
 	repeated Governance governances  = 4759;
 	LeastPrivilegePolicy least_privilege_policy = 12663;
+	MonitoringProcedure monitoring_procedure = 11357;
 	NeedToKnowPolicy need_to_know_policy = 3585;
+	NetworkThreatMitigationPolicy network_threat_mitigation_policy = 9407;
 	optional string parent_id = 18208;
 	SDNFunctionValidationPolicy sdn_function_validation_policy = 8099;
 	SchemaValidation validated_by = 5620;

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -218,6 +218,7 @@ message ApplicationLogging {
 // AssetInventory is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
 // AuditInterval contains the frequency of asset inventory audits in month.
 // Class representing the inventory of assets.
+// Service contains the name of the service (e.g., Asset Management).
 // Status contains the status of the asset (e.g., active, inactive).
 // StorageFacility contains the storage facility type of the asset (e.g., central, decentralized).
 // Type: contains the type of the asset, e.g., digital
@@ -233,8 +234,9 @@ message AssetInventory {
 	int32 audit_interval = 15088;
 	// Percentage of completed reviews and updates of asset inventory entries.
 	float completed_review_percentage = 15931;
-	string property = 11459;
 	int32 review_frequency = 12717;
+	// Service contains the name of the service (e.g., Asset Management).
+	string service = 11727;
 	string status = 11933;
 	string storage_facility = 2637;
 	string type = 11720;

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -233,6 +233,7 @@ message AssetInventory {
 	int32 audit_interval = 15088;
 	// Percentage of completed reviews and updates of asset inventory entries.
 	float completed_review_percentage = 15931;
+	string property = 11459;
 	int32 review_frequency = 12717;
 	string status = 11933;
 	string storage_facility = 2637;
@@ -578,13 +579,6 @@ message CipherSuite {
 	// naming schema: AES-128-GCM
 	string session_cipher = 5742;
 	repeated Cipher ciphers  = 8372;
-}
-
-// CloudFeature is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.
-message CloudFeature {
-	option (resource_type_names) = "CloudFeature";
-
-	string property = 15213;
 }
 
 // Infrastructure is an abstract class in our ontology, it cannot be instantiated but acts as an "interface".
@@ -3429,7 +3423,6 @@ message PolicyDocument {
 	AccessControlTypePolicy access_control_type_policy = 9164;
 	AssetInventory asset_inventory = 16496;
 	Backup backup = 16402;
-	CloudFeature cloud_feature = 1878;
 	repeated CryptographicHash cryptographic_hashs  = 12896;
 	DataConfidentialitySDNPolicy data_confidentiality_sdn_policy = 4864;
 	DataLocation data_location = 11474;

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -482,13 +482,6 @@
         <Class abbreviatedIRI="cl:PolicyDocument"/>
         <ObjectSomeValuesFrom>
             <ObjectProperty abbreviatedIRI="prop:has"/>
-            <Class abbreviatedIRI="cl:CloudFeature"/>
-        </ObjectSomeValuesFrom>
-    </SubClassOf>
-    <SubClassOf>
-        <Class abbreviatedIRI="cl:PolicyDocument"/>
-        <ObjectSomeValuesFrom>
-            <ObjectProperty abbreviatedIRI="prop:has"/>
             <Class abbreviatedIRI="cl:SecurityIncident"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>

--- a/ontology/v1/resource/document.owx
+++ b/ontology/v1/resource/document.owx
@@ -447,6 +447,27 @@
         <Class abbreviatedIRI="cl:PolicyDocument"/>
         <ObjectSomeValuesFrom>
             <ObjectProperty abbreviatedIRI="prop:has"/>
+            <Class abbreviatedIRI="cl:AccessControlTypePolicy"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="cl:PolicyDocument"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI="prop:has"/>
+            <Class abbreviatedIRI="cl:NetworkThreatMitigationPolicy"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="cl:PolicyDocument"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI="prop:has"/>
+            <Class abbreviatedIRI="cl:MonitoringProcedure"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class abbreviatedIRI="cl:PolicyDocument"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI="prop:has"/>
             <Class abbreviatedIRI="cl:AssetInventory"/>
         </ObjectSomeValuesFrom>
     </SubClassOf>


### PR DESCRIPTION
## Summary
Fixes #346. Several properties added in the AMOE metrics batch were declared in the ontology but never attached to their owning class, so the corresponding rego rules had no field to evaluate:

- `PolicyDocument` now `has` `AccessControlTypePolicy` (used by `AccessControlType`) and `NetworkThreatMitigationPolicy` (used by `MitigatedNetworkAttacks`)
- `CloudFeature` gained the `property` field (used by `AssetInventoryEnabled`)
- `AssetInventory` gained `reviewFrequency` (used by `AssetInventoryReviewFrequency`)
- `Backup` gained `frequency` (used by `BackupFrequency`) and `recoveryFrequency` (used by `BackupRecoveryFrequency`)

Additionally, `MonitoringProcedure` is now attached directly to `PolicyDocument` (rather than only reachable through the abstract, repeated `Governance` collection), and `MonitoringReviewFrequency`'s rego/description were updated to assess `monitoringProcedure` directly instead of nesting it under `governance`, per the issue's suggestion.

`ontology/v1/ontology.proto` and `ontology/v1/ontology-merged.owx` were regenerated locally using the same `robot merge` + `owl2proto generate-proto` pipeline the `ontology.yaml` CI workflow runs, so the diff is exactly the new fields — nothing else changed.

## Test plan
- [x] Regenerated `ontology.proto` via `robot merge` + `owl2proto generate-proto` and confirmed the diff contains only the 7 expected new fields/message members
- [x] `opa eval`'d each of the 6 affected `metric.rego` files against sample input containing the new fields, confirming `applicable: true` and `compliant: true`
- [ ] CI `ontology.yaml` workflow re-generates and confirms no diff