### PR TITLE
Fix AdminMFAEnabled: read enforceMfa and compare against true

### DIFF
--- a/metrics/IdentityManagement/AdminMFAEnabled/AdminMFAEnabled.yaml
+++ b/metrics/IdentityManagement/AdminMFAEnabled/AdminMFAEnabled.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: 2601ddd9-d98b-467d-ad5b-ebe1e333f566
 name: AdminMFAEnabled
-description: This rule assesses whether an [Identity] that has the property [p1:privileged] set respectively, also has the property [enforceMfa] [p2:enabled] correctly configured.
+description: This rule assesses whether an [Identity] that has the property [p1:privileged] set respectively, also has the property [enforceMFA] [p2:enabled] correctly configured.
 category: IdentityManagement
 version: "v1" 
 comments: MFA is a standard security measure for administrative users due to their extensive permissions. 

--- a/metrics/IdentityManagement/AdminMFAEnabled/AdminMFAEnabled.yaml
+++ b/metrics/IdentityManagement/AdminMFAEnabled/AdminMFAEnabled.yaml
@@ -1,7 +1,7 @@
 # ====== Metadata ======
 id: 2601ddd9-d98b-467d-ad5b-ebe1e333f566
 name: AdminMFAEnabled
-description: This rule assesses whether an [Identity] that has the property [p1:privileged] set respectively, also has the property [enforceMFA] [p2:enabled] correctly configured.
+description: This rule assesses whether an [Identity] that has the property [p1:privileged] set respectively, also has the property [enforceMfa] [p2:enabled] correctly configured.
 category: IdentityManagement
 version: "v1" 
 comments: MFA is a standard security measure for administrative users due to their extensive permissions. 

--- a/metrics/IdentityManagement/AdminMFAEnabled/data.json
+++ b/metrics/IdentityManagement/AdminMFAEnabled/data.json
@@ -1,4 +1,4 @@
 {
-    "operator": ">=",
-    "target_value": 2
+    "operator" : "==",
+    "target_value" : true
 }

--- a/metrics/IdentityManagement/AdminMFAEnabled/metric.rego
+++ b/metrics/IdentityManagement/AdminMFAEnabled/metric.rego
@@ -9,7 +9,9 @@ default applicable = false
 default compliant = false
 
 applicable if {
-	# we are only interested in some kind of privileged user    
+	"Identity" in identity.type
+
+	# we are only interested in some kind of privileged user
 	identity.privileged
 }
 

--- a/metrics/IdentityManagement/AdminMFAEnabled/metric.rego
+++ b/metrics/IdentityManagement/AdminMFAEnabled/metric.rego
@@ -14,5 +14,5 @@ applicable if {
 }
 
 compliant if {
-	compare(data.operator, data.target_value, identity.enforceMFA)
+	compare(data.operator, data.target_value, identity.enforceMfa)
 }


### PR DESCRIPTION
`AdminMFAEnabled` cannot evaluate on real evidence today, for two independent
reasons:

1. The rule reads `identity.enforceMFA`, but `Identity` serialises that field
   as `enforceMfa` (`json_name=enforceMfa`), so the key is never present.
2. `data.json` held `>= 2` while `AdminMFAEnabled.yaml` declares `==` / `True`.
   `enforceMfa` is a boolean, so `>= 2` cannot be satisfied.

Verified with OPA 1.19.1, input typed `Identity` with `privileged: true`:
`enforceMfa: true` now compliant (was false), `enforceMfa: false`
non-compliant. Non-privileged identities remain not applicable.
