### PR TITLE
metrics: Add BackupEnabled

### DIFF
--- a/metrics/Backup/BackupEnabled/BackupEnabled.yaml
+++ b/metrics/Backup/BackupEnabled/BackupEnabled.yaml
@@ -1,10 +1,10 @@
 # ====== Metadata ======
-id: 40f80c7d-a300-4eca-8b43-d4ac575ecc77
+id: c7a4fae4-216a-4440-93e9-637cb08d79a8
 name: BackupEnabled
-description: This rule assesses whether a resource that offers [p1:backups] has backup [p1:enabled].
-category: Backup
+description: This rule assesses whether a [Storage] includes [Backup] with [p1:enabled] set correctly.
+category: "Backup"
 version: "v1" 
-comments: The existing Backup metrics assess a policy document. This one assesses the resource itself, so an estate can be shown to have backups configured rather than only documented.
+comments: This metric assesses whether a storage resource has backups configured.
 # ====== Configuration ======
 configuration:
   p1:

--- a/metrics/Backup/BackupEnabled/BackupEnabled.yaml
+++ b/metrics/Backup/BackupEnabled/BackupEnabled.yaml
@@ -1,0 +1,12 @@
+# ====== Metadata ======
+id: 40f80c7d-a300-4eca-8b43-d4ac575ecc77
+name: BackupEnabled
+description: This rule assesses whether a resource that offers [p1:backups] has backup [p1:enabled].
+category: Backup
+version: "v1" 
+comments: The existing Backup metrics assess a policy document. This one assesses the resource itself, so an estate can be shown to have backups configured rather than only documented.
+# ====== Configuration ======
+configuration:
+  p1:
+    operator: "=="
+    targetValue: True

--- a/metrics/Backup/BackupEnabled/data.json
+++ b/metrics/Backup/BackupEnabled/data.json
@@ -1,0 +1,4 @@
+{
+    "operator" : "==",
+    "target_value" : true
+}

--- a/metrics/Backup/BackupEnabled/metric.rego
+++ b/metrics/Backup/BackupEnabled/metric.rego
@@ -10,6 +10,7 @@ default compliant = false
 
 applicable if {
 	storage.backups != {}
+	count(storage.backups) > 0
 	"Storage" in storage.type
 }
 

--- a/metrics/Backup/BackupEnabled/metric.rego
+++ b/metrics/Backup/BackupEnabled/metric.rego
@@ -1,0 +1,17 @@
+package cch.metrics.backup_enabled
+
+import data.cch.compare
+import rego.v1
+import input.backups as backups
+
+default applicable = false
+
+default compliant = false
+
+applicable if {
+	backups
+}
+
+compliant if {
+	compare(data.operator, data.target_value, backups[_].enabled)
+}

--- a/metrics/Backup/BackupEnabled/metric.rego
+++ b/metrics/Backup/BackupEnabled/metric.rego
@@ -2,16 +2,17 @@ package cch.metrics.backup_enabled
 
 import data.cch.compare
 import rego.v1
-import input.backups as backups
+import input as storage
 
 default applicable = false
 
 default compliant = false
 
 applicable if {
-	backups
+	storage.backups != {}
+	"Storage" in storage.type
 }
 
 compliant if {
-	compare(data.operator, data.target_value, backups[_].enabled)
+	compare(data.operator, data.target_value, storage.backups[_].enabled)
 }


### PR DESCRIPTION
`BackupFrequency` and `BackupRecoveryFrequency` both apply to `PolicyDocument`,
so the catalogue can assess that backups are *documented* but not that they are
*configured*. This adds the resource-level counterpart, reading the ontology's
`backups` property (present on `BlockStorage`, `FileStorage`,
`DatabaseStorage` and `ObjectStorage`).

Verified with OPA 1.19.1 against `metrics/operators.rego`:

| `backups` | applicable | compliant |
|---|---|---|
| `[{"enabled": true}]` | true | true |
| `[{"enabled": false}]` | true | false |
| absent | false | false |

UUID checked with `scripts/check_duplicate_uuids.py`; YAML validated against
`metric_schema.json`.
