### PR TITLE
ontology: Add allowedSources to L3Firewall

### DIFF
--- a/ontology/v1/core/security.owx
+++ b/ontology/v1/core/security.owx
@@ -872,6 +872,13 @@
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>
+        <Class abbreviatedIRI="core:L3Firewall"/>
+        <DataSomeValuesFrom>
+            <DataProperty abbreviatedIRI="prop:allowedSources"/>
+            <Datatype abbreviatedIRI="xsd:listString"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
         <Class abbreviatedIRI="core:LibraryEntryPoint"/>
         <Class abbreviatedIRI="core:LocalEntryPoint"/>
     </SubClassOf>


### PR DESCRIPTION
As requested in the Pilot 4 thread: adds allowedSources (xsd:listString) to L3Firewall, the field the two bastion-only metrics on CaixaBank's list need. Same shape as restrictedPorts. Our addon already reads the rule sources from the security groups and will emit them once this is deployed.