### PR TITLE
Regenerate merged ontology and proto for restrictedPorts and allowedSources lists

### DIFF
--- a/ontology/v1/ontology-merged.owx
+++ b/ontology/v1/ontology-merged.owx
@@ -1629,6 +1629,9 @@
         <Datatype IRI="/datatypes/listCpgNodes"/>
     </Declaration>
     <Declaration>
+        <DataProperty IRI="/properties/allowedSources"/>
+    </Declaration>
+    <Declaration>
         <DataProperty IRI="/classes/modelStealResilience"/>
     </Declaration>
     <Declaration>
@@ -3661,6 +3664,13 @@
     <SubClassOf>
         <Class IRI="/classes/L3Firewall"/>
         <DataSomeValuesFrom>
+            <DataProperty IRI="/properties/allowedSources"/>
+            <Datatype abbreviatedIRI="xsd:listString"/>
+        </DataSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="/classes/L3Firewall"/>
+        <DataSomeValuesFrom>
             <DataProperty IRI="/properties/enabled"/>
             <Datatype abbreviatedIRI="xsd:boolean"/>
         </DataSomeValuesFrom>
@@ -3676,7 +3686,7 @@
         <Class IRI="/classes/L3Firewall"/>
         <DataSomeValuesFrom>
             <DataProperty IRI="/properties/restrictedPorts"/>
-            <Datatype abbreviatedIRI="xsd:string"/>
+            <Datatype abbreviatedIRI="xsd:listString"/>
         </DataSomeValuesFrom>
     </SubClassOf>
     <SubClassOf>

--- a/ontology/v1/ontology.proto
+++ b/ontology/v1/ontology.proto
@@ -2442,9 +2442,10 @@ message L3Firewall {
 	option (resource_type_names) = "Authorization";
 	option (resource_type_names) = "SecurityFeature";
 
+	repeated string allowed_sources = 4470;
 	bool enabled = 9476;
 	bool inbound = 1000;
-	string restricted_ports = 7341;
+	repeated string restricted_ports = 7341;
 }
 
 // LeastPrivilegePolicy is an entity class in our ontology. It can be instantiated and contains all of its properties as well of its implemented interfaces.


### PR DESCRIPTION
Commits the files the ontology workflow generated on #356; the auto-commit step is skipped for fork PRs, so main still had the old proto.